### PR TITLE
Fix empty point inputs being set to null

### DIFF
--- a/src/routes/(authed)/grades/[index]/+page.svelte
+++ b/src/routes/(authed)/grades/[index]/+page.svelte
@@ -319,6 +319,14 @@
 	}
 
 	function recalculateGradePercentage() {
+		// Fix Svelte treating empty numeric inputs as "null"
+		hypotheticalAssignments = hypotheticalAssignments.map((assignment) => {
+			if (assignment.pointsEarned === null) assignment.pointsEarned = NaN;
+			if (assignment.pointsPossible === null) assignment.pointsPossible = NaN;
+
+			return assignment;
+		});
+
 		calculateHypotheticalGrade(hypotheticalAssignments);
 	}
 


### PR DESCRIPTION
Svelte numeric bindings treat an empty input as "null". This messes up the "not graded" feature which expects pointsEarned to be NaN, not null.